### PR TITLE
Adds links to config repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This extension is still in preview, it may not work, it may stop working at any 
 
 ### Find all references
 
-![Find all references](./docs/findallrefs.gif)
+![Find all references](./docs/findallrefs.png)
 
 ## Usage
 
@@ -78,3 +78,11 @@ This extension is still in preview, it may not work, it may stop working at any 
 6. Follow the prompts to select your vanilla folder
 7. Edit files and watch syntax errors show up when you make mistakes
 8. Wait up to a minute for the extension to scan all your mods and find all errors
+
+## Links 
+* [vic2-config](https://github.com/cwtools/cwtools-vic2-config)
+* [ck2-config](https://github.com/cwtools/cwtools-ck2-config)
+* [eu4-config](https://github.com/cwtools/cwtools-eu4-config)
+* [hoi4-config](https://github.com/cwtools/cwtools-hoi4-config)
+* [stellaris-config](https://github.com/cwtools/cwtools-stellaris-config)
+* [ir-config](https://github.com/cwtools/cwtools-ir-config)


### PR DESCRIPTION
The "find all references" picture pointed to a picture that doesn't exist.
I also thought that it would be a good idea to have links to the config repos on the front page.