### PR TITLE
Fix reading zero-length zip archive

### DIFF
--- a/src/Main/Serialize.fs
+++ b/src/Main/Serialize.fs
@@ -56,12 +56,15 @@ let addDLCs (workspaceDirectory: WorkspaceDirectory) =
             match Directory.EnumerateFiles dlcDir |> Seq.tryFind (fun f -> (Path.GetExtension f) = ".zip") with
             | Some zip ->
                 // eprintfn "d2 %A" zip
-                use file = File.OpenRead(zip)
-                use zipFile = ZipArchive(file, ZipArchiveMode.Read)
-                let files = zipFile.Entries |> Seq.map (fun e -> Path.Combine([|"uri:"; zip; e.FullName.Replace("\\","/")|]), use sr = StreamReader(e.Open()) in sr.ReadToEnd())
-                            |> List.ofSeq
+                try
+                    use file = File.OpenRead(zip)
+                    use zipFile = ZipArchive(file, ZipArchiveMode.Read)
+                    let files = zipFile.Entries |> Seq.map (fun e -> Path.Combine([|"uri:"; zip; e.FullName.Replace("\\","/")|]), use sr = StreamReader(e.Open()) in sr.ReadToEnd())
+                                |> List.ofSeq
                 // eprintfn "%A" files
-                Some (ZD { ZippedDirectory.name = Path.GetFileName zip; path = zip.Replace("\\","/"); files = files})
+                    Some (ZD { ZippedDirectory.name = Path.GetFileName zip; path = zip.Replace("\\","/"); files = files})
+                with
+                | _ -> None
             | None -> None
         dlcs |> Seq.choose createZippedDirectory |> List.ofSeq
     else


### PR DESCRIPTION
The Galactic Paragons expansion for Stellaris has a null zip file that causes `createZippedDirectory()` to choke. Adding a `try` block fixes this.